### PR TITLE
Users should be able to see job postings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,5 +29,9 @@ module.exports = {
         "react"
     ],
     "rules": {
+        "quotes": ["error", "single"],
+        "semi": ["error", "always"],
+        "@typescript-eslint/semi": "off",
+        "indent": ["error", 2],
     }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.vscode

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,37 @@
 import React from 'react';
 import { Container } from 'semantic-ui-react';
 import NavigationBar from './Navigation/NavigationBar';
-import JobPosting from './Jobs/JobPosting';
+import JobPostings from './Jobs/JobPostings';
+import { type JobPostingType } from './Types/Jobs/types';
 import 'semantic-ui-css/semantic.min.css';
 
 const App: React.FC = () => {
+  const data: JobPostingType[] = [
+    {
+      _id: '6246db5be7676f0018395187',
+      company_logo: 'https://res.cloudinary.com/shz/image/upload/v1584468335/OKJob/mailchimp-logo.svg',
+      id: 'mailchimp-3966706',
+      title: 'Staff Systems Engineer, Foundry',
+      location: 'remote',
+      company_name: 'mailchimp',
+      date: '2022-04-01T11:00:43.063Z'
+    },
+    {
+      _id: '6246db5be7676f0018395187',
+      company_logo: 'https://res.cloudinary.com/shz/image/upload/v1584468335/OKJob/mailchimp-logo.svg',
+      id: 'mailchimp-3966706',
+      title: 'Staff Systems Engineer, Foundry',
+      location: 'remote',
+      company_name: 'mailchimp',
+      date: '2022-04-01T11:00:43.063Z'
+    }
+  ];
+
   return (
     <div className="App">
       <NavigationBar />
       <Container>
-        <JobPosting />
+        <JobPostings jobPostings={data} />
       </Container>
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,18 @@
-import React from 'react'
-import NavigationBar from './Navigation/NavigationBar'
-import 'semantic-ui-css/semantic.min.css'
-import './App.css'
+import React from 'react';
+import { Container } from 'semantic-ui-react';
+import NavigationBar from './Navigation/NavigationBar';
+import JobPosting from './Jobs/JobPosting';
+import 'semantic-ui-css/semantic.min.css';
 
 const App: React.FC = () => {
   return (
     <div className="App">
-        <NavigationBar />
+      <NavigationBar />
+      <Container>
+        <JobPosting />
+      </Container>
     </div>
-  )
-}
+  );
+};
 
-export default App
+export default App;

--- a/src/Jobs/JobPosting.tsx
+++ b/src/Jobs/JobPosting.tsx
@@ -1,41 +1,28 @@
 import React from 'react';
 import { Segment, Item, Label } from 'semantic-ui-react';
 import { capitalizeFirstLetter } from '../utils/dataManipulation';
+import { type JobPostingType } from '../Types/Jobs/types';
 
-interface JobPostingType {
-  _id: string
-  company_logo: string
-  id: string
-  title: string
-  location: string
-  company_name: string
-  date: string
+interface JobPostingProps {
+  jobPosting: JobPostingType
 }
 
-const JobPosting: React.FC = () => {
-  const data: JobPostingType = {
-    _id: '6246db5be7676f0018395187',
-    company_logo: 'https://res.cloudinary.com/shz/image/upload/v1584468335/OKJob/mailchimp-logo.svg',
-    id: 'mailchimp-3966706',
-    title: 'Staff Systems Engineer, Foundry',
-    location: 'remote',
-    company_name: 'mailchimp',
-    date: '2022-04-01T11:00:43.063Z'
-  };
+const JobPosting: React.FunctionComponent<JobPostingProps> = (props) => {
+  const { jobPosting } = props;
 
   return (
     <Segment>
       <Item.Group divided>
         <Item>
-          <Item.Image size='tiny' src={data.company_logo} />
+          <Item.Image size='tiny' src={jobPosting.company_logo} />
           <Item.Content>
-            <Item.Header as='a'>{data.title}</Item.Header>
+            <Item.Header as='a'>{jobPosting.title}</Item.Header>
             <Item.Meta>
-              <span className='cinema'>{data.company_name}</span>
+              <span className='cinema'>{jobPosting.company_name}</span>
             </Item.Meta>
             <Item.Description>{ }</Item.Description>
             <Item.Extra>
-              <Label>Location: {capitalizeFirstLetter(data.location)}</Label>
+              <Label>Location: {capitalizeFirstLetter(jobPosting.location)}</Label>
             </Item.Extra>
           </Item.Content>
         </Item>

--- a/src/Jobs/JobPosting.tsx
+++ b/src/Jobs/JobPosting.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Segment, Item, Label } from 'semantic-ui-react';
+import { capitalizeFirstLetter } from '../utils/dataManipulation';
+
+interface JobPostingType {
+  _id: string
+  company_logo: string
+  id: string
+  title: string
+  location: string
+  company_name: string
+  date: string
+}
+
+const JobPosting: React.FC = () => {
+  const data: JobPostingType = {
+    _id: '6246db5be7676f0018395187',
+    company_logo: 'https://res.cloudinary.com/shz/image/upload/v1584468335/OKJob/mailchimp-logo.svg',
+    id: 'mailchimp-3966706',
+    title: 'Staff Systems Engineer, Foundry',
+    location: 'remote',
+    company_name: 'mailchimp',
+    date: '2022-04-01T11:00:43.063Z'
+  };
+
+  return (
+    <Segment>
+      <Item.Group divided>
+        <Item>
+          <Item.Image size='tiny' src={data.company_logo} />
+          <Item.Content>
+            <Item.Header as='a'>{data.title}</Item.Header>
+            <Item.Meta>
+              <span className='cinema'>{data.company_name}</span>
+            </Item.Meta>
+            <Item.Description>{ }</Item.Description>
+            <Item.Extra>
+              <Label>Location: {capitalizeFirstLetter(data.location)}</Label>
+            </Item.Extra>
+          </Item.Content>
+        </Item>
+      </Item.Group>
+    </Segment>
+  );
+};
+
+export default JobPosting;

--- a/src/Jobs/JobPostings.tsx
+++ b/src/Jobs/JobPostings.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { type JobPostingType } from '../Types/Jobs/types';
+import JobPosting from './JobPosting';
+
+interface JobPostingsProps {
+  jobPostings: JobPostingType[]
+}
+
+const JobPostings: React.FunctionComponent<JobPostingsProps> = (props) => {
+  const { jobPostings } = props;
+
+  return (
+    <>
+      {jobPostings.map((jobPosting: JobPostingType) => (
+        <JobPosting key={jobPosting.id} jobPosting={jobPosting} />
+      ))}
+    </>
+  );
+};
+
+export default JobPostings;

--- a/src/Types/Jobs/types.ts
+++ b/src/Types/Jobs/types.ts
@@ -1,0 +1,9 @@
+export interface JobPostingType {
+  _id: string
+  company_logo: string
+  id: string
+  title: string
+  location: string
+  company_name: string
+  date: string
+};

--- a/src/utils/dataManipulation.ts
+++ b/src/utils/dataManipulation.ts
@@ -1,0 +1,7 @@
+const capitalizeFirstLetter = (str: string): string => {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+};
+
+export {
+  capitalizeFirstLetter
+};


### PR DESCRIPTION
A user should be able to see job postings shown on the browser. But the job postings are dummy data. The job postings will soon come from an external API.

![image](https://github.com/ryanchangyeolshin/remoote/assets/16450416/079ae7b8-3f73-4de5-8b69-5aa914d93db1)
